### PR TITLE
rfac: show controller target ray at all times

### DIFF
--- a/apps/controller-interaction.js
+++ b/apps/controller-interaction.js
@@ -72,12 +72,10 @@ class App {
         const ray = this.buildRay();
 
         function onSelectStart() {
-            this.children[0].scale.z = 10;
             this.userData.selectPressed = true;
         }
 
         function onSelectEnd() {
-            this.children[0].scale.z = 0;
             this.userData.selectPressed = false;
         }
 
@@ -111,7 +109,7 @@ class App {
 
         const line = new THREE.Line(geometry);
         line.name = "line";
-        line.scale.z = 0;
+        line.scale.z = 10;
 
         return line;
     }

--- a/apps/equirect-buttons.js
+++ b/apps/equirect-buttons.js
@@ -86,12 +86,10 @@ class App {
         const ray = this.buildRay();
 
         function onSelectStart() {
-            this.children[0].scale.z = 10;
             this.userData.selectPressed = true;
         }
 
         function onSelectEnd() {
-            this.children[0].scale.z = 0;
             this.userData.selectPressed = false;
         }
 
@@ -128,7 +126,7 @@ class App {
 
         const line = new THREE.Line(geometry);
         line.name = "line";
-        line.scale.z = 0;
+        line.scale.z = 10;
 
         return line;
     }

--- a/apps/simple-video-layers/equirect.js
+++ b/apps/simple-video-layers/equirect.js
@@ -77,12 +77,10 @@ class App {
         const ray = this.buildRay();
 
         function onSelectStart() {
-            this.children[0].scale.z = 10;
             this.userData.selectPressed = true;
         }
 
         function onSelectEnd() {
-            this.children[0].scale.z = 0;
             this.userData.selectPressed = false;
         }
 
@@ -119,7 +117,7 @@ class App {
 
         const line = new THREE.Line(geometry);
         line.name = "line";
-        line.scale.z = 0;
+        line.scale.z = 10;
 
         return line;
     }

--- a/apps/simple-video-layers/multiple-layers.js
+++ b/apps/simple-video-layers/multiple-layers.js
@@ -91,12 +91,10 @@ class App {
         const ray = this.buildRay();
 
         function onSelectStart() {
-            this.children[0].scale.z = 10;
             this.userData.selectPressed = true;
         }
 
         function onSelectEnd() {
-            this.children[0].scale.z = 0;
             this.userData.selectPressed = false;
         }
 
@@ -133,7 +131,7 @@ class App {
 
         const line = new THREE.Line(geometry);
         line.name = "line";
-        line.scale.z = 0;
+        line.scale.z = 10;
 
         return line;
     }


### PR DESCRIPTION
## Description

This PR refactors the code for controllers to display the target ray at all times instead of showing it only when the select button is pressed.