### PR TITLE
feat: progress bar playback

### DIFF
--- a/apps/equirect-buttons.js
+++ b/apps/equirect-buttons.js
@@ -300,7 +300,7 @@ class App {
     createProgressBar() {
         const barGroup = new THREE.Group();
 
-        const bgBarGeometry = new THREE.PlaneGeometry(2, 0.1);
+        const bgBarGeometry = new THREE.PlaneGeometry(1, 0.1);
         const bgBarMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff });
         const bgBarMesh = new THREE.Mesh(bgBarGeometry, bgBarMaterial);
 
@@ -322,14 +322,23 @@ class App {
         const redProgressBar = this.progressBar.getObjectByName(
             "red progress bar"
         );
+        const whiteProgressBar = this.progressBar.getObjectByName(
+            "white progress bar"
+        );
+
         const progress = (this.video.currentTime / this.video.duration) * 2;
         redProgressBar.scale.set(progress, 1, 1);
-        const offset = (2 - progress) / 2;
-        redProgressBar.position.x = -offset;
+        const redOffset = (2 - progress) / 2;
+        redProgressBar.position.x = -redOffset;
         redProgressBar.position.needsUpdate = true;
+
+        whiteProgressBar.scale.set(2 - progress, 1, 1);
+        const whiteOffset = progress / 2;
+        whiteProgressBar.position.x = whiteOffset;
+        whiteProgressBar.position.needsUpdate = true;
     }
 
-    setVideoTime(xPosition) {
+    setVideoCurrentTime(xPosition) {
         // Set video playback position
         const timeFraction = (xPosition + 1) / 2;
         this.video.currentTime = timeFraction * this.video.duration;
@@ -393,20 +402,13 @@ class App {
                 this.scene.remove(this.toolbarGroup);
             }
 
-            // console.log(intersections);
-
-            const redProgressBar = this.progressBar.getObjectByName(
-                "red progress bar"
+            const intersectionWithProgressBar = intersections.find(
+                ({ object: { name } }) =>
+                    name === "white progress bar" || name === "red progress bar"
             );
-            const whiteProgressBar = this.progressBar.getObjectByName(
-                "white progress bar"
-            );
-            const intersectionWithWhiteBar = intersections.find(
-                ({ object: { name } }) => name === "white progress bar"
-            );
-            if (intersectionWithWhiteBar) {
-                redProgressBar.position.x = intersectionWithWhiteBar.point.x;
-                this.setVideoTime(intersectionWithWhiteBar.point.x);
+            if (intersectionWithProgressBar) {
+                this.setVideoCurrentTime(intersectionWithProgressBar.point.x);
+                this.updateProgressBar();
             }
         }
     }

--- a/apps/equirect-buttons.js
+++ b/apps/equirect-buttons.js
@@ -4,9 +4,9 @@ import { XRControllerModelFactory } from "three/examples/jsm/webxr/XRControllerM
 
 import panoVideo from "../media/pano.mp4";
 import buttonClickSound from "../media/audio/button-click.mp3";
-import { CanvasUI } from "../util/CanvasUI";
 import { WebGLRenderer } from "../util/WebGLRenderer";
 import { VRButton } from "../util/webxr/VRButton";
+import Toolbar from "../util/Toolbar";
 
 class App {
     constructor(videoIn = panoVideo) {
@@ -26,23 +26,19 @@ class App {
         // Create Orbit Controls
         this.controls = this.createOrbitControls();
 
+        // Create Video
+        this.video = this.createVideo(videoIn);
+
         // Track which objects are hit
         this.raycaster = new THREE.Raycaster();
 
-        // Create Canvas UI
-        this.ui = this.createUI();
-
-        // Create Progress Bar
-        this.progressBar = this.createProgressBar();
-
         // Create Toolbar Group
-        this.toolbarGroup = this.createToolbarGroup();
+        // prettier-ignore
+        this.toolbar = new Toolbar(this.renderer, this.video, true);
+        this.toolbarGroup = this.toolbar.toolbar;
 
         // Hide the toolbar initially
         this.scene.userData.isToolbarVisible = false;
-
-        // Create Video
-        this.video = this.createVideo(videoIn);
 
         this.setupVR();
 
@@ -58,12 +54,12 @@ class App {
         const xr = this.renderer.xr;
         const session = xr.getSession();
 
-        if (xr.isPresenting) {
-            this.ui.update();
+        if (xr.isPresenting && this.toolbarGroup) {
+            this.toolbar.updateUI();
         }
 
-        if (this.video) {
-            this.updateProgressBar();
+        if (this.toolbar.video) {
+            this.toolbar.updateProgressBar();
         }
 
         if (
@@ -203,159 +199,6 @@ class App {
     }
 
     /**
-     * Creates a toolbar with playback controls
-     */
-    createUI() {
-        const onRestart = () => {
-            this.video.currentTime = 0;
-        };
-
-        const onSkip = (val) => {
-            this.video.currentTime += val;
-        };
-
-        const onPlayPause = () => {
-            const paused = this.video.paused;
-            console.log(paused);
-
-            if (paused) {
-                this.video.play();
-            } else {
-                this.video.pause();
-            }
-
-            const label = paused ? "||" : "►";
-            this.ui.updateElement("pause", label);
-        };
-
-        const colors = {
-            blue: {
-                light: "#1bf",
-                lighter: "#3df",
-            },
-            red: "#f00",
-            white: "#fff",
-            yellow: {
-                bright: "#ff0",
-                dark: "#bb0",
-            },
-        };
-
-        const config = {
-            panelSize: { width: 2, height: 0.5 },
-            opacity: 1,
-            height: 128,
-            prev: {
-                type: "button",
-                position: { top: 32, left: 0 },
-                width: 64,
-                fontColor: colors.yellow.dark,
-                hover: colors.yellow.bright,
-                onSelect: () => onSkip(-5),
-            },
-            pause: {
-                type: "button",
-                position: { top: 35, left: 64 },
-                width: 128,
-                height: 52,
-                fontColor: colors.white,
-                backgroundColor: colors.red,
-                hover: colors.yellow.bright,
-                onSelect: onPlayPause,
-            },
-            next: {
-                type: "button",
-                position: { top: 32, left: 192 },
-                width: 64,
-                fontColor: colors.yellow.dark,
-                hover: colors.yellow.bright,
-                onSelect: () => onSkip(5),
-            },
-            restart: {
-                type: "button",
-                position: { top: 35, right: 10 },
-                width: 200,
-                height: 52,
-                fontColor: colors.white,
-                backgroundColor: colors.blue.light,
-                hover: colors.blue.lighter,
-                onSelect: onRestart,
-            },
-            renderer: this.renderer,
-        };
-
-        const content = {
-            prev: "<path>M 10 32 L 54 10 L 54 54 Z</path>",
-            pause: "||",
-            next: "<path>M 54 32 L 10 10 L 10 54 Z</path>",
-            restart: "Restart",
-        };
-
-        const ui = new CanvasUI(content, config);
-        ui.mesh.position.set(0, -1, -3);
-
-        return ui;
-    }
-
-    createProgressBar() {
-        const barGroup = new THREE.Group();
-
-        const bgBarGeometry = new THREE.PlaneGeometry(1, 0.1);
-        const bgBarMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff });
-        const bgBarMesh = new THREE.Mesh(bgBarGeometry, bgBarMaterial);
-
-        const barGeometry = new THREE.PlaneGeometry(1, 0.1);
-        const barMaterial = new THREE.MeshBasicMaterial({ color: 0xff031b });
-        const barMesh = new THREE.Mesh(barGeometry, barMaterial);
-
-        const { x, y, z } = this.ui.mesh.position;
-        barMesh.name = "red progress bar";
-        barGroup.add(barMesh);
-        bgBarMesh.name = "white progress bar";
-        barGroup.add(bgBarMesh);
-        barGroup.position.set(x, y + 0.3, z);
-
-        return barGroup;
-    }
-
-    updateProgressBar() {
-        const redProgressBar = this.progressBar.getObjectByName(
-            "red progress bar"
-        );
-        const whiteProgressBar = this.progressBar.getObjectByName(
-            "white progress bar"
-        );
-
-        const progress = (this.video.currentTime / this.video.duration) * 2;
-        redProgressBar.scale.set(progress, 1, 1);
-        const redOffset = (2 - progress) / 2;
-        redProgressBar.position.x = -redOffset;
-        redProgressBar.position.needsUpdate = true;
-
-        whiteProgressBar.scale.set(2 - progress, 1, 1);
-        const whiteOffset = progress / 2;
-        whiteProgressBar.position.x = whiteOffset;
-        whiteProgressBar.position.needsUpdate = true;
-    }
-
-    setVideoCurrentTime(xPosition) {
-        // Set video playback position
-        const timeFraction = (xPosition + 1) / 2;
-        this.video.currentTime = timeFraction * this.video.duration;
-    }
-
-    createToolbarGroup() {
-        const toolbarGroup = new THREE.Group();
-        toolbarGroup.add(this.ui.mesh);
-        toolbarGroup.add(this.progressBar);
-
-        toolbarGroup.position.set(0, 1.6, -2);
-        toolbarGroup.rotateX(-Math.PI / 4);
-
-        return toolbarGroup;
-    }
-
-    /**
      * Creates an HTML video using `videoIn` as src attribute
      * @param {} videoIn video.src
      */
@@ -392,24 +235,16 @@ class App {
                 .set(0, 0, -1)
                 .applyMatrix4(worldMatrix);
 
-            const intersections = this.raycaster.intersectObjects([
-                this.ui.mesh,
-                ...this.progressBar.children,
-            ]);
+            const intersections = this.raycaster.intersectObjects(
+                this.toolbar.objects
+            );
 
             if (intersections.length === 0) {
                 this.scene.userData.isToolbarVisible = false;
                 this.scene.remove(this.toolbarGroup);
             }
 
-            const intersectionWithProgressBar = intersections.find(
-                ({ object: { name } }) =>
-                    name === "white progress bar" || name === "red progress bar"
-            );
-            if (intersectionWithProgressBar) {
-                this.setVideoCurrentTime(intersectionWithProgressBar.point.x);
-                this.updateProgressBar();
-            }
+            this.toolbar.update(intersections);
         }
     }
 

--- a/apps/equirect-buttons.js
+++ b/apps/equirect-buttons.js
@@ -4,9 +4,9 @@ import { XRControllerModelFactory } from "three/examples/jsm/webxr/XRControllerM
 
 import panoVideo from "../media/pano.mp4";
 import buttonClickSound from "../media/audio/button-click.mp3";
+import Toolbar from "../util/Toolbar";
 import { WebGLRenderer } from "../util/WebGLRenderer";
 import { VRButton } from "../util/webxr/VRButton";
-import Toolbar from "../util/Toolbar";
 
 class App {
     constructor(videoIn = panoVideo) {
@@ -33,9 +33,8 @@ class App {
         this.raycaster = new THREE.Raycaster();
 
         // Create Toolbar Group
-        // prettier-ignore
-        this.toolbar = new Toolbar(this.renderer, this.video, true);
-        this.toolbarGroup = this.toolbar.toolbar;
+        this.toolbar = this.createToolbar();
+        this.toolbarGroup = this.toolbar.toolbarGroup;
 
         // Hide the toolbar initially
         this.scene.userData.isToolbarVisible = false;
@@ -198,6 +197,11 @@ class App {
         return scene;
     }
 
+    createToolbar() {
+        const toolbar = new Toolbar(this.renderer, this.video, true);
+        return toolbar;
+    }
+
     /**
      * Creates an HTML video using `videoIn` as src attribute
      * @param {} videoIn video.src
@@ -242,9 +246,10 @@ class App {
             if (intersections.length === 0) {
                 this.scene.userData.isToolbarVisible = false;
                 this.scene.remove(this.toolbarGroup);
+            } else {
+                // Handle the intersection with Toolbar
+                this.toolbar.update(intersections);
             }
-
-            this.toolbar.update(intersections);
         }
     }
 

--- a/apps/equirect-buttons.js
+++ b/apps/equirect-buttons.js
@@ -7,6 +7,7 @@ import buttonClickSound from "../media/audio/button-click.mp3";
 import { CanvasUI } from "../util/CanvasUI";
 import { WebGLRenderer } from "../util/WebGLRenderer";
 import { VRButton } from "../util/webxr/VRButton";
+import { Group } from "three";
 
 class App {
     constructor(videoIn = panoVideo) {
@@ -29,8 +30,13 @@ class App {
         // Track which objects are hit
         this.raycaster = new THREE.Raycaster();
 
+        const toolbarGroup = new THREE.Group();
         // Create Canvas UI
         this.ui = this.createUI();
+        toolbarGroup.add(this.ui.mesh);
+        this.progressBar = this.createProgressBar();
+        toolbarGroup.add(this.progressBar);
+
         // Hide the toolbar initially
         this.scene.userData.isToolbarVisible = false;
 
@@ -295,6 +301,13 @@ class App {
         return ui;
     }
 
+    createProgressBar() {
+        const barGeometry = new THREE.PlaneGeometry(2, 0.01);
+        const barMaterial = new THREE.MeshBasicMaterial({ color: 0xffff00 });
+        const barMesh = new THREE.Mesh(barGeometry, barMaterial);
+        return barMesh;
+    }
+
     /**
      * Creates an HTML video using `videoIn` as src attribute
      * @param {} videoIn video.src
@@ -318,6 +331,7 @@ class App {
                 this.scene.userData.isToolbarVisible = true;
                 this.scene.add(this.ui.mesh);
                 return;
+            } else {
             }
 
             // Make toolbar disappear if no interaction with toolbar
@@ -362,9 +376,6 @@ class App {
 
         this.controllers = this.buildControllers();
         for (let controller of this.controllers) {
-            controller.addEventListener("connected", () => {
-                this.scene.add(this.ui.mesh);
-            });
             controller.addEventListener("disconnected", () => {
                 this.scene.remove(this.ui.mesh);
             });

--- a/util/Toolbar.js
+++ b/util/Toolbar.js
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { CanvasUI } from "./CanvasUI";
+import { CanvasUI } from "../../util/CanvasUI";
 
 class Toolbar {
     constructor(renderer, videoIn, isAngled) {
@@ -16,7 +16,7 @@ class Toolbar {
 
         // Toolbar Group
         // prettier-ignore
-        this._toolbarGroup = this.createToolbarGroup(isAngled, {x: 3, y: 3, z: -2});
+        this._toolbarGroup = this.createToolbarGroup(isAngled, {x: 0, y: 1.6, z: -2});
     }
 
     get objects() {

--- a/util/Toolbar.js
+++ b/util/Toolbar.js
@@ -1,0 +1,205 @@
+import * as THREE from "three";
+
+import { CanvasUI } from "./CanvasUI";
+
+class Toolbar {
+    constructor(renderer, videoIn, isAngled) {
+        this._renderer = renderer;
+
+        this._video = videoIn;
+
+        // Buttons and Panel
+        this._ui = this.createUI(2, 0.5, 128, { x: 0, y: -1, z: -3 });
+
+        // Progress Bar
+        this._progressBar = this.createProgressBar();
+
+        // Toolbar Group
+        // prettier-ignore
+        this._toolbarGroup = this.createToolbarGroup(isAngled, {x: 3, y: 3, z: -2});
+    }
+
+    get objects() {
+        return [this._ui.mesh, ...this._progressBar.children];
+    }
+
+    get toolbar() {
+        return this._toolbarGroup;
+    }
+
+    get video() {
+        return this._video;
+    }
+
+    update(intersections) {
+        const intersectionWithProgressBar = intersections.find(
+            ({ object: { name } }) =>
+                name === "white progress bar" || name === "red progress bar"
+        );
+        if (intersectionWithProgressBar) {
+            this.setVideoCurrentTime(intersectionWithProgressBar.point.x);
+            this.updateProgressBar();
+        }
+    }
+
+    updateUI() {
+        this._ui.update();
+    }
+
+    /**
+     * Creates a toolbar with playback controls
+     */
+    createUI(panelWidth, panelHeight, height, { x, y, z }) {
+        const onRestart = () => {
+            this._video.currentTime = 0;
+        };
+
+        const onSkip = (val) => {
+            this._video.currentTime += val;
+        };
+
+        const onPlayPause = () => {
+            const paused = this._video.paused;
+            console.log(paused);
+
+            if (paused) {
+                this._video.play();
+            } else {
+                this._video.pause();
+            }
+
+            const label = paused ? "||" : "►";
+            this._ui.updateElement("pause", label);
+        };
+
+        const colors = {
+            blue: {
+                light: "#1bf",
+                lighter: "#3df",
+            },
+            red: "#f00",
+            white: "#fff",
+            yellow: {
+                bright: "#ff0",
+                dark: "#bb0",
+            },
+        };
+
+        const config = {
+            panelSize: { width: panelWidth, height: panelHeight },
+            opacity: 1,
+            height: height,
+            prev: {
+                type: "button",
+                position: { top: 32, left: 0 },
+                width: 64,
+                fontColor: colors.yellow.dark,
+                hover: colors.yellow.bright,
+                onSelect: () => onSkip(-5),
+            },
+            pause: {
+                type: "button",
+                position: { top: 35, left: 64 },
+                width: 128,
+                height: 52,
+                fontColor: colors.white,
+                backgroundColor: colors.red,
+                hover: colors.yellow.bright,
+                onSelect: onPlayPause,
+            },
+            next: {
+                type: "button",
+                position: { top: 32, left: 192 },
+                width: 64,
+                fontColor: colors.yellow.dark,
+                hover: colors.yellow.bright,
+                onSelect: () => onSkip(5),
+            },
+            restart: {
+                type: "button",
+                position: { top: 35, right: 10 },
+                width: 200,
+                height: 52,
+                fontColor: colors.white,
+                backgroundColor: colors.blue.light,
+                hover: colors.blue.lighter,
+                onSelect: onRestart,
+            },
+            renderer: this._renderer,
+        };
+
+        const content = {
+            prev: "<path>M 10 32 L 54 10 L 54 54 Z</path>",
+            pause: "||",
+            next: "<path>M 54 32 L 10 10 L 10 54 Z</path>",
+            restart: "Restart",
+        };
+
+        const ui = new CanvasUI(content, config);
+        ui.mesh.position.set(x, y, z);
+
+        return ui;
+    }
+
+    createProgressBar() {
+        const barGroup = new THREE.Group();
+
+        const bgBarGeometry = new THREE.PlaneGeometry(1, 0.1);
+        const bgBarMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff });
+        const bgBarMesh = new THREE.Mesh(bgBarGeometry, bgBarMaterial);
+
+        const barGeometry = new THREE.PlaneGeometry(1, 0.1);
+        const barMaterial = new THREE.MeshBasicMaterial({ color: 0xff031b });
+        const barMesh = new THREE.Mesh(barGeometry, barMaterial);
+
+        const { x, y, z } = this._ui.mesh.position;
+        barMesh.name = `red progress bar`;
+        barGroup.add(barMesh);
+        bgBarMesh.name = "white progress bar";
+        barGroup.add(bgBarMesh);
+        barGroup.position.set(x, y + 0.3, z);
+
+        return barGroup;
+    }
+
+    updateProgressBar() {
+        const redProgressBar = this._progressBar.getObjectByName(
+            "red progress bar"
+        );
+        const whiteProgressBar = this._progressBar.getObjectByName(
+            "white progress bar"
+        );
+
+        const progress = (this._video.currentTime / this._video.duration) * 2;
+        redProgressBar.scale.set(progress, 1, 1);
+        const redOffset = (2 - progress) / 2;
+        redProgressBar.position.x = -redOffset;
+        redProgressBar.position.needsUpdate = true;
+
+        whiteProgressBar.scale.set(2 - progress, 1, 1);
+        const whiteOffset = progress / 2;
+        whiteProgressBar.position.x = whiteOffset;
+        whiteProgressBar.position.needsUpdate = true;
+    }
+
+    createToolbarGroup(isAngled, { x, y, z }) {
+        const toolbarGroup = new THREE.Group();
+        toolbarGroup.add(this._ui.mesh);
+        toolbarGroup.add(this._progressBar);
+
+        toolbarGroup.position.set(x, y, z);
+        if (isAngled) {
+            toolbarGroup.rotateX(-Math.PI / 4);
+        }
+
+        return toolbarGroup;
+    }
+
+    setVideoCurrentTime(xPosition) {
+        // Set video playback position
+        const timeFraction = (xPosition + 1) / 2;
+        this._video.currentTime = timeFraction * this._video.duration;
+    }
+}
+
+export default Toolbar;


### PR DESCRIPTION
- Add progress bar plane mesh
- Update progress bar on each render
- Get intersection with progress bar and skip video to that position

Note:
Currently, the progress bar is implemented as two meshes, `"red progress bar"` and `"white progress bar"`. When user clicks any point in the `this.progressBar` group, both the `"red progress bar"` and `"white progress bar"` object meshes scale to the desired width, then their `position.x` properties are offset to the left and right, respectively, to make it look like they are expanding towards the right and left, respectively. 

Two things:
1. There might be a better way to implement the progress bar without having to scale the white progress bar too, but for now this is the approach to avoid flickering (can observe in 1e1816f)
2. There might be a better way to implement the scaling of the bars while keeping one side of the object meshes anchored... I searched for awhile but couldn't find

Closes #13 