### PR TITLE
Setup for multiple media layers support

### DIFF
--- a/apps/equirect-buttons.js
+++ b/apps/equirect-buttons.js
@@ -5,7 +5,6 @@ import { XRControllerModelFactory } from "three/examples/jsm/webxr/XRControllerM
 import panoVideo from "../media/pano.mp4";
 import buttonClickSound from "../media/audio/button-click.mp3";
 import MediaLayerManager from "../util/MediaLayerManager";
-import Toolbar from "../util/Toolbar";
 import { WebGLRenderer } from "../util/WebGLRenderer";
 import { VRButton } from "../util/webxr/VRButton";
 
@@ -30,19 +29,14 @@ class App {
         // Create Video
         this.video = this.createVideo(videoIn);
 
+        // Create Intersecting Point
+        this.intersectPoint = this.createIntersectPoint();
+
         // Track which objects are hit
         this.raycaster = new THREE.Raycaster();
 
-        // Create Toolbar Group
-        // this.toolbar = this.createToolbar();
-        // this.toolbarGroup = this.toolbar.toolbarGroup;
+        // Create Map of MediaLayers
         this.mediaLayers = new Map();
-
-        // Hide the toolbar initially
-        this.scene.userData.isToolbarVisible = false;
-
-        // Create Intersecting Point
-        this.intersectPoint = this.createIntersectPoint();
 
         this.setupVR();
 
@@ -79,15 +73,36 @@ class App {
         ) {
             session.hasMediaLayer = true;
             const mediaFactory = new MediaLayerManager(session, this.renderer);
+
+            const equirectToolbarPositionConfig = {
+                ui: {
+                    panelWidth: 2,
+                    panelHeight: 0.5,
+                    height: 128,
+                    position: { x: 0, y: -1, z: -3 },
+                },
+                toolbarGroup: {
+                    position: {
+                        x: 0,
+                        y: 1.6,
+                        z: -2,
+                    },
+                },
+            };
             const equirect = await mediaFactory.createMediaLayer(
                 this.video,
                 MediaLayerManager.EQUIRECT_LAYER,
                 {
                     layout: "stereo-top-bottom",
                 },
-                -Math.PI / 4
+                -Math.PI / 4,
+                equirectToolbarPositionConfig
             );
             this.mediaLayers.set("equirect", equirect);
+
+            // Hide toolbars initially
+            this.hideToolbars();
+
             session.updateRenderState({
                 layers: [equirect.videoLayer, session.renderState.layers[0]],
             });
@@ -207,11 +222,6 @@ class App {
         return scene;
     }
 
-    createToolbar() {
-        const toolbar = new Toolbar(this.renderer, this.video, -Math.PI / 4);
-        return toolbar;
-    }
-
     /**
      * Creates an HTML video using `videoIn` as src attribute
      * @param {} videoIn video.src
@@ -228,32 +238,40 @@ class App {
         return video;
     }
 
+    createIntersectPoint() {
+        const geometry = new THREE.CircleGeometry(0.02, 10);
+        const material = new THREE.MeshBasicMaterial({ color: 0xbbbbbb });
+        const intersectPoint = new THREE.Mesh(geometry, material);
+
+        return intersectPoint;
+    }
+
     /**
      * Gets an array of hits on the UI toolbar
      * @param {*} controller controller to detect hits from
      */
     handleTriggerPress(controller) {
-        // If toolbar not in view, display it
-        if (!this.scene.userData.isToolbarVisible) {
-            this.scene.userData.isToolbarVisible = true;
-            this.scene.add(this.mediaLayers.get("equirect").toolbarGroup);
-        } else {
-            // Make toolbar disappear if no interaction with toolbar
-            const intersections = this.handleToolbarIntersections(
-                controller,
-                this.mediaLayers.get("equirect").objects
-            );
-
-            if (intersections.length === 0) {
-                this.scene.userData.isToolbarVisible = false;
-                this.scene.remove(
-                    this.mediaLayers.get("equirect").toolbarGroup
-                );
+        this.mediaLayers.forEach((layerObj, layerKey) => {
+            // If toolbar not in view, display it
+            if (!this.scene.userData.isToolbarVisible[layerKey]) {
+                this.scene.userData.isToolbarVisible[layerKey] = true;
+                this.scene.add(layerObj.toolbarGroup);
             } else {
-                // Handle the intersection with Toolbar
-                this.mediaLayers.get("equirect").update(intersections);
+                // Make toolbar disappear if no interaction with toolbar
+                const intersections = this.handleToolbarIntersections(
+                    controller,
+                    layerObj.objects
+                );
+
+                if (intersections.length === 0) {
+                    this.scene.userData.isToolbarVisible[layerKey] = false;
+                    this.scene.remove(layerObj.toolbarGroup);
+                } else {
+                    // Handle the intersection with Toolbar
+                    layerObj.update(intersections);
+                }
             }
-        }
+        });
     }
 
     handleToolbarIntersections(controller, objects) {
@@ -276,12 +294,18 @@ class App {
 
         const intersections = this.raycaster.intersectObjects(objects);
 
-        if (!this.scene.userData.isToolbarVisible) {
+        let isAllToolbarsHidden = true;
+        this.mediaLayers.forEach((_layerObj, layerKey) => {
+            if (this.scene.userData.isToolbarVisible[layerKey]) {
+                isAllToolbarsHidden = false;
+            }
+        });
+        if (isAllToolbarsHidden) {
             this.scene.remove(this.intersectPoint);
             return;
         }
 
-        if (intersections.length > 0 && this.scene.userData.isToolbarVisible) {
+        if (intersections.length > 0 && !isAllToolbarsHidden) {
             this.scene.add(this.intersectPoint);
 
             const { x, y, z } = intersections[0].point;
@@ -294,12 +318,13 @@ class App {
         return intersections;
     }
 
-    createIntersectPoint() {
-        const geometry = new THREE.CircleGeometry(0.02, 10);
-        const material = new THREE.MeshBasicMaterial({ color: 0xbbbbbb });
-        const intersectPoint = new THREE.Mesh(geometry, material);
-
-        return intersectPoint;
+    hideToolbars() {
+        if (!this.scene.userData.isToolbarVisible) {
+            this.scene.userData.isToolbarVisible = {};
+        }
+        this.mediaLayers.forEach((_layerObj, layerName) => {
+            this.scene.userData.isToolbarVisible[layerName] = false;
+        });
     }
 
     /**

--- a/apps/simple-video-layers/multiple-layers.js
+++ b/apps/simple-video-layers/multiple-layers.js
@@ -49,15 +49,16 @@ class App {
             this.video.readyState
         ) {
             session.hasMediaLayer = true;
-            const mediaFactory = new MediaLayerManager(session);
-            const equirectLayer = await mediaFactory.createLayer(
+            const mediaFactory = new MediaLayerManager(session, this.renderer);
+            const equirect = await mediaFactory.createMediaLayer(
                 this.video,
                 MediaLayerManager.EQUIRECT_LAYER,
                 {
                     layout: "stereo-top-bottom",
-                }
+                },
+                -Math.PI / 4
             );
-            const quadLayer = await mediaFactory.createLayer(
+            const quad = await mediaFactory.createMediaLayer(
                 this.video,
                 MediaLayerManager.QUAD_LAYER,
                 {
@@ -68,12 +69,13 @@ class App {
                         z: -2.75,
                         w: 1.0,
                     }),
-                }
+                },
+                0
             );
             session.updateRenderState({
                 layers: [
-                    equirectLayer,
-                    quadLayer,
+                    equirect.videoLayer,
+                    quad.videoLayer,
                     session.renderState.layers[0],
                 ],
             });

--- a/index.html
+++ b/index.html
@@ -18,10 +18,10 @@
                         <p>A simple VR scene</p>
                     </a>
 
-                    <a href="/controller-interraction" class="card">
+                    <a href="/controller-interaction" class="card">
                         <h3>Controller Interaction</h3>
                         <p>
-                            A simple VR scene showing controller Interractions
+                            A simple VR scene showing controller interactions
                         </p>
                     </a>
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", () => {
     let app;
 
     switch (window.location.pathname) {
-        case "/controller-interraction":
+        case "/controller-interaction":
             app = new ControllerInteraction();
             break;
         case "/simple-scene":

--- a/util/GlassLayer.js
+++ b/util/GlassLayer.js
@@ -1,0 +1,9 @@
+import MediaLayer from "./MediaLayer";
+
+class GlassLayer {
+    constructor(renderer) {
+        this.renderer = renderer;
+    }
+}
+
+export default GlassLayer;

--- a/util/MediaLayer.js
+++ b/util/MediaLayer.js
@@ -1,0 +1,46 @@
+import Toolbar from "./Toolbar";
+import GlassLayer from "./GlassLayer";
+
+class MediaLayer {
+    constructor(layer, rotateXAngle, video, session, renderer) {
+        this.videoLayer = layer;
+        this.video = video;
+        this.session = session;
+        this.renderer = renderer;
+
+        this.toolbar = this.createToolbar(rotateXAngle);
+
+        this.glassLayer = this.createGlassLayer();
+    }
+
+    get objects() {
+        return this.toolbar.objects;
+    }
+
+    get toolbarGroup() {
+        return this.toolbar.toolbarGroup;
+    }
+
+    createGlassLayer() {
+        const glass = new GlassLayer(this.renderer);
+    }
+
+    createToolbar(rotateXAngle) {
+        const toolbar = new Toolbar(this.renderer, this.video, rotateXAngle);
+        return toolbar;
+    }
+
+    move() {}
+
+    resize() {}
+
+    update(intersections) {
+        this.toolbar.update(intersections);
+    }
+
+    updateOnRender(isXRPresenting) {
+        this.toolbar.updateOnRender(isXRPresenting);
+    }
+}
+
+export default MediaLayer;

--- a/util/MediaLayer.js
+++ b/util/MediaLayer.js
@@ -2,13 +2,20 @@ import Toolbar from "./Toolbar";
 import GlassLayer from "./GlassLayer";
 
 class MediaLayer {
-    constructor(layer, rotateXAngle, video, session, renderer) {
+    constructor(
+        layer,
+        rotateXAngle,
+        video,
+        session,
+        renderer,
+        toolbarPositionConfig
+    ) {
         this.videoLayer = layer;
         this.video = video;
         this.session = session;
         this.renderer = renderer;
 
-        this.toolbar = this.createToolbar(rotateXAngle);
+        this.toolbar = this.createToolbar(rotateXAngle, toolbarPositionConfig);
 
         this.glassLayer = this.createGlassLayer();
     }
@@ -25,8 +32,13 @@ class MediaLayer {
         const glass = new GlassLayer(this.renderer);
     }
 
-    createToolbar(rotateXAngle) {
-        const toolbar = new Toolbar(this.renderer, this.video, rotateXAngle);
+    createToolbar(rotateXAngle, positionConfig) {
+        const toolbar = new Toolbar(
+            this.renderer,
+            this.video,
+            rotateXAngle,
+            positionConfig
+        );
         return toolbar;
     }
 

--- a/util/MediaLayerManager.js
+++ b/util/MediaLayerManager.js
@@ -1,6 +1,9 @@
+import MediaLayer from "./MediaLayer";
+
 class MediaLayerManager {
-    constructor(session) {
+    constructor(session, renderer) {
         this.session = session;
+        this.renderer = renderer;
         this.mediaFactory = this.createMediaFactory();
     }
 
@@ -18,6 +21,17 @@ class MediaLayerManager {
     createMediaFactory() {
         const mediaFactory = new XRMediaBinding(this.session);
         return mediaFactory;
+    }
+
+    async createMediaLayer(video, layerType, options, rotateXAngle) {
+        const layer = await this.createLayer(video, layerType, options);
+        return new MediaLayer(
+            layer,
+            rotateXAngle,
+            this.video,
+            this.session,
+            this.renderer
+        );
     }
 
     /**

--- a/util/MediaLayerManager.js
+++ b/util/MediaLayerManager.js
@@ -28,7 +28,7 @@ class MediaLayerManager {
         return new MediaLayer(
             layer,
             rotateXAngle,
-            this.video,
+            video,
             this.session,
             this.renderer
         );

--- a/util/MediaLayerManager.js
+++ b/util/MediaLayerManager.js
@@ -23,14 +23,21 @@ class MediaLayerManager {
         return mediaFactory;
     }
 
-    async createMediaLayer(video, layerType, options, rotateXAngle) {
+    async createMediaLayer(
+        video,
+        layerType,
+        options,
+        rotateXAngle,
+        toolbarPositionConfig
+    ) {
         const layer = await this.createLayer(video, layerType, options);
         return new MediaLayer(
             layer,
             rotateXAngle,
             video,
             this.session,
-            this.renderer
+            this.renderer,
+            toolbarPositionConfig
         );
     }
 

--- a/util/Toolbar.js
+++ b/util/Toolbar.js
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { CanvasUI } from "../../util/CanvasUI";
+import { CanvasUI } from "./CanvasUI";
 
 class Toolbar {
     constructor(renderer, videoIn, isAngled) {

--- a/util/Toolbar.js
+++ b/util/Toolbar.js
@@ -3,24 +3,22 @@ import * as THREE from "three";
 import { CanvasUI } from "./CanvasUI";
 
 class Toolbar {
-    constructor(renderer, video, rotateXAngle) {
+    constructor(renderer, video, rotateXAngle, positionConfig) {
         this.renderer = renderer;
 
-        console.log(video);
         this.video = video;
 
         // Buttons and Panel
-        this.ui = this.createUI(2, 0.5, 128, { x: 0, y: -1, z: -3 });
+        this.ui = this.createUI(positionConfig.ui);
 
         // Progress Bar
         this.progressBar = this.createProgressBar();
 
         // Toolbar Group
-        this.toolbarGroup = this.createToolbarGroup(rotateXAngle, {
-            x: 0,
-            y: 1.6,
-            z: -2,
-        });
+        this.toolbarGroup = this.createToolbarGroup(
+            rotateXAngle,
+            positionConfig.toolbarGroup
+        );
     }
 
     get objects() {
@@ -49,7 +47,7 @@ class Toolbar {
         return barGroup;
     }
 
-    createToolbarGroup(rotateXAngle, { x, y, z }) {
+    createToolbarGroup(rotateXAngle, { position: { x, y, z } }) {
         const toolbarGroup = new THREE.Group();
         toolbarGroup.add(this.ui.mesh);
         toolbarGroup.add(this.progressBar);
@@ -63,7 +61,7 @@ class Toolbar {
     /**
      * Creates a toolbar with playback controls
      */
-    createUI(panelWidth, panelHeight, height, { x, y, z }) {
+    createUI({ panelWidth, panelHeight, height, position: { x, y, z } }) {
         const onRestart = () => {
             this.video.currentTime = 0;
         };
@@ -155,7 +153,6 @@ class Toolbar {
     }
 
     setVideoCurrentTime(xPosition) {
-        console.log(this.video);
         // Set video playback position
         const timeFraction = (xPosition + 1) / 2;
         this.video.currentTime = timeFraction * this.video.duration;

--- a/util/Toolbar.js
+++ b/util/Toolbar.js
@@ -3,10 +3,11 @@ import * as THREE from "three";
 import { CanvasUI } from "./CanvasUI";
 
 class Toolbar {
-    constructor(renderer, videoIn, isAngled) {
+    constructor(renderer, video, rotateXAngle) {
         this.renderer = renderer;
 
-        this.video = videoIn;
+        console.log(video);
+        this.video = video;
 
         // Buttons and Panel
         this.ui = this.createUI(2, 0.5, 128, { x: 0, y: -1, z: -3 });
@@ -15,7 +16,7 @@ class Toolbar {
         this.progressBar = this.createProgressBar();
 
         // Toolbar Group
-        this.toolbarGroup = this.createToolbarGroup(isAngled, {
+        this.toolbarGroup = this.createToolbarGroup(rotateXAngle, {
             x: 0,
             y: 1.6,
             z: -2,
@@ -48,15 +49,13 @@ class Toolbar {
         return barGroup;
     }
 
-    createToolbarGroup(isAngled, { x, y, z }) {
+    createToolbarGroup(rotateXAngle, { x, y, z }) {
         const toolbarGroup = new THREE.Group();
         toolbarGroup.add(this.ui.mesh);
         toolbarGroup.add(this.progressBar);
 
         toolbarGroup.position.set(x, y, z);
-        if (isAngled) {
-            toolbarGroup.rotateX(-Math.PI / 4);
-        }
+        toolbarGroup.rotateX(rotateXAngle);
 
         return toolbarGroup;
     }
@@ -156,6 +155,7 @@ class Toolbar {
     }
 
     setVideoCurrentTime(xPosition) {
+        console.log(this.video);
         // Set video playback position
         const timeFraction = (xPosition + 1) / 2;
         this.video.currentTime = timeFraction * this.video.duration;
@@ -169,6 +169,16 @@ class Toolbar {
 
         if (intersectionWithProgressBar) {
             this.setVideoCurrentTime(intersectionWithProgressBar.point.x);
+            this.updateProgressBar();
+        }
+    }
+
+    updateOnRender(isXRPresenting) {
+        if (isXRPresenting && this.toolbarGroup) {
+            this.updateUI();
+        }
+
+        if (this.video) {
             this.updateProgressBar();
         }
     }


### PR DESCRIPTION
1. Added MediaLayer, GlassLayer classes
   - Each MediaLayer is tagged to one Toolbar
2. Added createMediaLayer() method in MediaLayerManager that creates MediaLayer objects
3. Updated multiple-layers.js to create separate independent video DOM elements per MediaLayer
   - Each layer's toolbar controls only affect that layer's video

Builds on top of #22. Changes are from fbad184.