### PR TITLE
Change videos for all samples, clean up hand-input sample

### DIFF
--- a/apps/simple-video-layers/equirect.js
+++ b/apps/simple-video-layers/equirect.js
@@ -2,12 +2,14 @@ import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { XRControllerModelFactory } from "three/examples/jsm/webxr/XRControllerModelFactory";
 
-import panoVideo from "../../media/pano.mp4";
 import { WebGLRenderer } from "../../util/WebGLRenderer";
 import { VRButton } from "../../util/webxr/VRButton";
 
+const SLOTH_TOP_BOTTOM_VIDEO =
+    "https://d25a56pc18k0co.cloudfront.net/sloths_binaural_3840x2160_360_3D_v2_injected.mp4";
+
 class App {
-    constructor(videoIn = panoVideo) {
+    constructor(videoIn = SLOTH_TOP_BOTTOM_VIDEO) {
         const container = document.createElement("div");
         document.body.appendChild(container);
 
@@ -178,7 +180,14 @@ class App {
     createVideo(videoIn) {
         const video = document.createElement("video");
         video.loop = true;
+        video.crossOrigin = "anonymous";
+        video.preload = "auto";
+        video.autoload = true;
         video.src = videoIn;
+
+        video.onloadedmetadata = () => {
+            console.log("Video loaded");
+        };
 
         return video;
     }

--- a/apps/simple-video-layers/multiple-layers.js
+++ b/apps/simple-video-layers/multiple-layers.js
@@ -11,6 +11,8 @@ const SLOTH_TOP_BOTTOM_VIDEO =
     "https://d25a56pc18k0co.cloudfront.net/sloths_binaural_3840x2160_360_3D_v2_injected.mp4";
 const SLOTH_LEFT_RIGHT_VIDEO =
     "https://d25a56pc18k0co.cloudfront.net/sloths_binaural_3840_180_3D-injected.mp4";
+const BUNNY_VIDEO =
+    "https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4";
 
 class App {
     constructor(videoIn = SLOTH_TOP_BOTTOM_VIDEO) {
@@ -39,7 +41,7 @@ class App {
         // Create Map of Videos for Each Layer
         this.videos = this.createVideos({
             equirect: videoIn,
-            quad: videoIn,
+            quad: BUNNY_VIDEO,
         });
 
         this.setupVR();
@@ -119,6 +121,8 @@ class App {
                 MediaLayerManager.QUAD_LAYER,
                 {
                     layout: "stereo-top-bottom",
+                    width: 1.0,
+                    height: 0.5625,
                     transform: new XRRigidTransform({
                         x: 0.0,
                         y: 1.3,
@@ -442,8 +446,8 @@ class App {
         if (!this.scene.userData.isToolbarVisible) {
             this.scene.userData.isToolbarVisible = {};
         }
-        
-        for(const layerKey of this.mediaLayers.keys()) {
+
+        for (const layerKey of this.mediaLayers.keys()) {
             this.scene.userData.isToolbarVisible[layerKey] = false;
         }
     }


### PR DESCRIPTION
Replace all quad videos with [this video](https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_1080p_h264.mov/BigBuckBunny_320x180.mp4). Takes awhile to load even though it seems like it's the smallest.

Other changes include changing the hand model to "spheres" (because there's a bug with "oculus"), and cleaning up `hand-input` sample.